### PR TITLE
misc: .gitattributes for Solidity syntax highlighting on github.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
See https://github.com/github/linguist/pull/3973 for PR that added this to `github/linguist`.

(Consider adding such a file to other repos that have Solidity files.)

-----

### Added
* Miscellaneous: Solidity files on github now have syntax highlighting.
### Changed

### Deprecated

### Removed

### Fixed

### Security
