### PR TITLE
Canonicalfeed intervention

### DIFF
--- a/src/pricefeeds/CanonicalPriceFeed.sol
+++ b/src/pricefeeds/CanonicalPriceFeed.sol
@@ -249,8 +249,8 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
     }
 
     function setMinimumPriceCount(uint newCount) auth { minimumPriceCount = newCount; }
-    function enableUpdates() auth { updatesAreAllowed = true; }
-    function disableUpdates() auth { updatesAreAllowed = false; }
+    // function enableUpdates() auth { updatesAreAllowed = true; }
+    // function disableUpdates() auth { updatesAreAllowed = false; }
 
     // PUBLIC VIEW METHODS
 

--- a/src/pricefeeds/CanonicalPriceFeed.sol
+++ b/src/pricefeeds/CanonicalPriceFeed.sol
@@ -131,7 +131,7 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
     {
         OperatorStaking.stake(amount, data);
     }
-  
+
     function stakeFor(
         address user,
         uint amount,
@@ -188,6 +188,9 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
             uint[] memory assetPrices = new uint[](operators.length);
             for (uint j = 0; j < operators.length; j++) {
                 SimplePriceFeed feed = SimplePriceFeed(operators[j]);
+                if (feed.isPaused()) {
+                    continue;
+                }
                 var (price, timestamp) = feed.assetsToPrices(ofAssets[i]);
                 if (now > add(timestamp, VALIDITY)) {
                     continue; // leaves a zero in the array (dealt with later)
@@ -266,6 +269,7 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
     function hasRecentPrice(address ofAsset)
         view
         pre_cond(assetIsRegistered(ofAsset))
+        pre_cond(!isPaused)
         returns (bool isRecent)
     {
         var ( , timestamp) = getPrice(ofAsset);
@@ -400,7 +404,7 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
     }
 
     // UPDATE TRACKING
- 
+
     /// @return Timestamp for the last epoch, regardless of whether an update occurred for it
     function getLastEpochTime() view returns (uint) { // TODO: special case for zero INTERVAL?
         uint timeSinceLastEpoch = sub(block.timestamp, INCEPTION) % INTERVAL;
@@ -411,7 +415,7 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
         uint lastEpochTime = getLastEpochTime();
         return add(lastEpochTime, INTERVAL);
     }
- 
+
     // TODO: may not be necessary in the end. Remove if commented out during cleanup.
     // /// @return Whether a new epoch has occurred since the last full canonical update
     // function isNewEpoch() view returns (bool) { // TODO: special case for zero INTERVAL?

--- a/src/pricefeeds/SimplePriceFeed.sol
+++ b/src/pricefeeds/SimplePriceFeed.sol
@@ -24,7 +24,8 @@ contract SimplePriceFeed is SimplePriceFeedInterface, DSThing, DBC {
     address public QUOTE_ASSET; // Asset of a portfolio against which all other assets are priced
 
     // Contract-level variables
-    uint public updateId;        // Update counter for this pricefeed; used as a check during investment
+    uint public updateId; // Update counter for this pricefeed; used as a check during investment
+    bool public isPaused; // Is Pricefeed paused by the owner; Only price fetching is effected
     CanonicalRegistrar public registrar;
     CanonicalPriceFeed public superFeed;
 
@@ -65,6 +66,22 @@ contract SimplePriceFeed is SimplePriceFeedInterface, DSThing, DBC {
         superFeed.subFeedPostUpdateHook();
     }
 
+    /// @notice Pause the pricefeed so price fetches throw
+    function pause()
+        external
+        auth
+    {
+        isPaused = true;
+    }
+
+    /// @notice Unpause the pricefeed
+    function unpause()
+        external
+        auth
+    {
+        isPaused = false;
+    }
+
     // PUBLIC VIEW METHODS
 
     // Get pricefeed specific information
@@ -82,6 +99,7 @@ contract SimplePriceFeed is SimplePriceFeedInterface, DSThing, DBC {
     */
     function getPrice(address ofAsset)
         view
+        pre_cond(!isPaused)
         returns (uint price, uint timestamp)
     {
         Data data = assetsToPrices[ofAsset];
@@ -99,6 +117,7 @@ contract SimplePriceFeed is SimplePriceFeedInterface, DSThing, DBC {
     */
     function getPrices(address[] ofAssets)
         view
+        pre_cond(!isPaused)
         returns (uint[], uint[])
     {
         uint[] memory prices = new uint[](ofAssets.length);

--- a/src/pricefeeds/SimplePriceFeed.sol
+++ b/src/pricefeeds/SimplePriceFeed.sol
@@ -67,20 +67,9 @@ contract SimplePriceFeed is SimplePriceFeedInterface, DSThing, DBC {
     }
 
     /// @notice Pause the pricefeed so price fetches throw
-    function pause()
-        external
-        auth
-    {
-        isPaused = true;
-    }
-
+    function pause() external auth { isPaused = true; }
     /// @notice Unpause the pricefeed
-    function unpause()
-        external
-        auth
-    {
-        isPaused = false;
-    }
+    function unpause() external auth { isPaused = false; }
 
     // PUBLIC VIEW METHODS
 


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

-  Function governance can call to pause Canonical pricefeed. Pausing only makes price fetching functions to throw.
- Unit test for above

### Changed

### Deprecated

### Removed

- Commented unused enableUpdates and disableUpdates functions as Canonical Pricefeed is hitting gas limit of 6900000

### Fixed

### Security
