### PR TITLE
Fix getReferencePriceInfo

### DIFF
--- a/src/pricefeeds/CanonicalPriceFeed.sol
+++ b/src/pricefeeds/CanonicalPriceFeed.sol
@@ -333,7 +333,7 @@ contract CanonicalPriceFeed is OperatorStaking, SimplePriceFeed, CanonicalRegist
             var (isRecentBase, referencePriceBase, decimalBase) = getPriceInfo(ofBase);
             var (isRecentQuote, referencePriceQuote, decimalQuote) = getPriceInfo(ofQuote);
             isRecent = isRecentBase && isRecentQuote;
-            referencePrice = mul(referencePriceBase, decimalQuote) / referencePriceQuote;
+            referencePrice = mul(referencePriceBase, 10 ** uint(decimalQuote)) / referencePriceQuote;
             decimal = decimalQuote;
         }
     }


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### API Breaking Changes

### Documentation Changes

### Added

### Changed

### Deprecated

### Removed

### Fixed
- getReferencePriceInfo function 

### Security
