### PR TITLE
Update to token-math@0.0.10 --> BREAKING CHANGES!

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^3.1.1"
   },
   "dependencies": {
-    "@melonproject/token-math": "^0.0.7",
+    "@melonproject/token-math": "0.0.10",
     "@parity/api": "^2.1.20",
     "bignumber.js": "^4.1.0",
     "debug": "^4.0.1",

--- a/src/contracts/dependencies/token/calls/balanceOf.test.ts
+++ b/src/contracts/dependencies/token/calls/balanceOf.test.ts
@@ -1,4 +1,4 @@
-import { Quantity } from '@melonproject/token-math';
+import { createQuantity, isEqual } from '@melonproject/token-math/quantity';
 
 import { initTestEnvironment, getGlobalEnvironment } from '~/utils/environment';
 
@@ -18,7 +18,7 @@ test('balanceOf', async () => {
     address: environment.wallet.address,
   });
 
-  const expected = Quantity.createQuantity(
+  const expected = createQuantity(
     {
       address: shared.address,
       decimals: 18,
@@ -27,5 +27,5 @@ test('balanceOf', async () => {
     '1000000000000000000000000',
   );
 
-  expect(Quantity.isEqual(balance, expected)).toBe(true);
+  expect(isEqual(balance, expected)).toBe(true);
 });

--- a/src/contracts/dependencies/token/calls/balanceOf.ts
+++ b/src/contracts/dependencies/token/calls/balanceOf.ts
@@ -1,4 +1,4 @@
-import { Quantity } from '@melonproject/token-math';
+import { createQuantity } from '@melonproject/token-math/quantity';
 
 import { getGlobalEnvironment } from '~/utils/environment';
 import { getToken } from '..';
@@ -16,5 +16,5 @@ export const balanceOf = async (
   );
   const tokenMathToken = await getToken(contractAddress, environment);
   const result = await contract.methods.balanceOf(address).call();
-  return Quantity.createQuantity(tokenMathToken, result);
+  return createQuantity(tokenMathToken, result);
 };

--- a/src/contracts/dependencies/token/calls/getToken.ts
+++ b/src/contracts/dependencies/token/calls/getToken.ts
@@ -1,11 +1,11 @@
-import { IToken } from '@melonproject/token-math';
+import { TokenInterface } from '@melonproject/token-math/token';
 import { getInfo } from '..';
 import { Contract, getContract } from '~/utils/solidity';
 
 export const getToken = async (
   contractAddress,
   environment?,
-): Promise<IToken> => {
+): Promise<TokenInterface> => {
   const contract = getContract(
     Contract.PreminedToken,
     contractAddress,

--- a/src/contracts/dependencies/token/transactions/approve.test.ts
+++ b/src/contracts/dependencies/token/transactions/approve.test.ts
@@ -1,4 +1,4 @@
-import { Quantity } from '@melonproject/token-math';
+import { createQuantity } from '@melonproject/token-math/quantity';
 
 import { initTestEnvironment, getGlobalEnvironment } from '~/utils/environment';
 import { Address } from '~/utils/types';
@@ -17,9 +17,9 @@ beforeAll(async () => {
 test('transfer', async () => {
   const environment = getGlobalEnvironment();
   const accounts = await environment.eth.getAccounts();
-  const howMuch = Quantity.createQuantity(shared.token, '1000000000000000000');
+  const howMuch = createQuantity(shared.token, '1000000000000000000');
 
-  const receipt = await approve(howMuch, new Address(accounts[1]));
+  const receipt = await approve({ howMuch, spender: new Address(accounts[1]) });
 
   expect(receipt).toBeTruthy();
 });

--- a/src/contracts/exchanges/transactions/addTokenPairWhitelist.ts
+++ b/src/contracts/exchanges/transactions/addTokenPairWhitelist.ts
@@ -1,15 +1,18 @@
-import { Token, IToken } from '@melonproject/token-math';
+import {
+  isToken,
+  hasAddress,
+  log,
+  TokenInterface,
+} from '@melonproject/token-math/token';
 
 import { getGlobalEnvironment } from '~/utils/environment';
 import { ensure } from '~/utils/guards';
 
 import { getContract, Contract } from '~/utils/solidity';
 
-const { isToken, hasAddress, log } = Token;
-
 interface IAddTokenPairWhitelist {
-  quoteToken: IToken;
-  baseToken: IToken;
+  quoteToken: TokenInterface;
+  baseToken: TokenInterface;
 }
 
 export const guards = async (

--- a/src/contracts/factory/transactions/createComponents.ts
+++ b/src/contracts/factory/transactions/createComponents.ts
@@ -1,4 +1,4 @@
-import { IToken } from '@melonproject/token-math';
+import { TokenInterface } from '@melonproject/token-math/token';
 
 import { Address } from '~/utils/types';
 import {
@@ -18,8 +18,8 @@ interface ExchangeConfig {
 interface CreateComponentsArgs {
   fundName: string;
   exchangeConfigs: ExchangeConfig[];
-  quoteToken: IToken;
-  defaultTokens: IToken[];
+  quoteToken: TokenInterface;
+  defaultTokens: TokenInterface[];
   priceSource: Address;
 }
 

--- a/src/contracts/prices/calls/getPrices.ts
+++ b/src/contracts/prices/calls/getPrices.ts
@@ -1,16 +1,16 @@
 import * as R from 'ramda';
 
-import { IToken, Price, Quantity, Token } from '@melonproject/token-math';
+import { getPrice } from '@melonproject/token-math/price';
+import { appendDecimals, TokenInterface } from '@melonproject/token-math/token';
+import { createQuantity } from '@melonproject/token-math/quantity';
 
 import { Environment } from '~/utils/environment';
 import { getQuoteToken } from '..';
 import { Contract, getContract } from '~/utils/solidity';
 
-const getPrice = Price.getPrice;
-
 export const getPrices = async (
   contractAddress: string,
-  tokens: IToken[],
+  tokens: TokenInterface[],
   environment?: Environment,
 ) => {
   const quoteToken = await getQuoteToken(contractAddress, environment);
@@ -31,9 +31,9 @@ export const getPrices = async (
 
   const processed = R.zipWith(processResult, result['0'], result['1']);
 
-  const createPrice = (t: IToken, { price, timestamp }) => {
-    const base = Quantity.createQuantity(t, Token.appendDecimals(t, 1));
-    const quote = Quantity.createQuantity(quoteToken, price);
+  const createPrice = (t: TokenInterface, { price, timestamp }) => {
+    const base = createQuantity(t, appendDecimals(t, 1));
+    const quote = createQuantity(quoteToken, price);
     return getPrice(base, quote);
   };
 

--- a/src/contracts/prices/calls/getQuoteToken.ts
+++ b/src/contracts/prices/calls/getQuoteToken.ts
@@ -1,4 +1,4 @@
-import { IToken } from '@melonproject/token-math';
+import { TokenInterface } from '@melonproject/token-math/token';
 
 import { Environment } from '~/utils/environment';
 import { Contract, getContract } from '~/utils/solidity';
@@ -6,7 +6,7 @@ import { Contract, getContract } from '~/utils/solidity';
 export const getQuoteToken = async (
   contractAddress: string,
   environment?: Environment,
-): Promise<IToken> => {
+): Promise<TokenInterface> => {
   const contract = await getContract(
     Contract.TestingPriceFeed,
     contractAddress,

--- a/src/contracts/prices/transactions/deploy.ts
+++ b/src/contracts/prices/transactions/deploy.ts
@@ -1,10 +1,13 @@
-import { IToken } from '@melonproject/token-math';
+import { TokenInterface } from '@melonproject/token-math/token';
 
 import { Environment } from '~/utils/environment';
 import { deploy as deployContract } from '~/utils/solidity';
 import { ensureAddress } from '~/utils/checks';
 
-export const deploy = async (quoteToken: IToken, environment?: Environment) => {
+export const deploy = async (
+  quoteToken: TokenInterface,
+  environment?: Environment,
+) => {
   ensureAddress(quoteToken.address);
 
   const address = await deployContract(

--- a/src/contracts/prices/transactions/update.test.ts
+++ b/src/contracts/prices/transactions/update.test.ts
@@ -1,4 +1,5 @@
-import { Price, Quantity, Token } from '@melonproject/token-math';
+import { createQuantity } from '@melonproject/token-math/quantity';
+import { getPrice, isEqual } from '@melonproject/token-math/price';
 
 import { initTestEnvironment } from '~/utils/environment';
 
@@ -24,18 +25,12 @@ beforeAll(async () => {
 });
 
 test('update', async () => {
-  const newPrice = Price.getPrice(
-    Quantity.createQuantity(
-      shared.mlnToken,
-      Token.appendDecimals(shared.mlnToken, 1),
-    ),
-    Quantity.createQuantity(
-      shared.quoteToken,
-      Token.appendDecimals(shared.quoteToken, 0.34),
-    ),
+  const newPrice = getPrice(
+    createQuantity(shared.mlnToken, 1),
+    createQuantity(shared.quoteToken, 0.34),
   );
 
   const receipt = await update(shared.address, [newPrice]);
 
-  expect(Price.isEqual(receipt[0], newPrice)).toBe(true);
+  expect(isEqual(receipt[0], newPrice)).toBe(true);
 });

--- a/src/utils/deploySystem.ts
+++ b/src/utils/deploySystem.ts
@@ -1,4 +1,6 @@
-import { Price, Quantity, Token } from '@melonproject/token-math';
+import { createQuantity } from '@melonproject/token-math/quantity';
+import { getPrice } from '@melonproject/token-math/price';
+
 import { initTestEnvironment, getGlobalEnvironment } from '~/utils/environment';
 import { Address } from '~/utils/types';
 
@@ -110,17 +112,17 @@ export const deploySystem = async () => {
     policy: priceToleranceAddress,
   });
 
-  const newPrice = Price.getPrice(
-    Quantity.createQuantity(baseToken, Token.appendDecimals(baseToken, 1)),
-    Quantity.createQuantity(quoteToken, Token.appendDecimals(quoteToken, 0.34)),
+  const newPrice = getPrice(
+    createQuantity(baseToken, 1),
+    createQuantity(quoteToken, 0.34),
   );
 
   await update(priceFeedAddress, [newPrice]);
 
-  await approve(
-    Quantity.createQuantity(baseToken, Token.appendDecimals(baseToken, 1)),
-    new Address(accounts[1]),
-  );
+  await approve({
+    howMuch: createQuantity(baseToken, 1),
+    spender: new Address(accounts[1]),
+  });
 };
 
 if (require.main === module) {

--- a/src/utils/solidity/deploy.ts
+++ b/src/utils/solidity/deploy.ts
@@ -1,10 +1,13 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { BigInteger } from '@melonproject/token-math';
+import {
+  BigInteger,
+  toBI,
+  greaterThan,
+} from '@melonproject/token-math/bigInteger';
 
 import { getGlobalEnvironment, getWeb3Options } from '~/utils/environment';
 
-const { toBI, greaterThan } = BigInteger;
 const debug = require('~/utils/getDebug').default(__filename);
 
 type ConstructorArg = number | string;

--- a/src/utils/solidity/prepareTransaction.ts
+++ b/src/utils/solidity/prepareTransaction.ts
@@ -1,9 +1,8 @@
-import { BigInteger } from '@melonproject/token-math';
+import { toBI, greaterThan } from '@melonproject/token-math/bigInteger';
 
 import { getGlobalEnvironment } from '~/utils/environment';
 
 const debug = require('~/utils/getDebug').default(__filename);
-const { toBI, greaterThan } = BigInteger;
 
 export interface PreparedTransaction {
   encoded: string;
@@ -18,7 +17,7 @@ export const prepareTransaction = async (
 ): Promise<PreparedTransaction> => {
   const encoded = transaction.encodeABI();
   const gasEstimation = await transaction.estimateGas({
-    from: environment.wallet.address,
+    from: environment.wallet.address.toString(),
   });
 
   debug(

--- a/yarn.lock
+++ b/yarn.lock
@@ -883,10 +883,10 @@
     pretty-ms "^0.2.1"
     text-table "^0.2.0"
 
-"@melonproject/token-math@^0.0.7":
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/@melonproject/token-math/-/token-math-0.0.7.tgz#a7195cad30aaebfb9975eb43d9c712a3b2e6f97b"
-  integrity sha512-xkAn0GFzk0W8Mkd9wGkyx5hlklBfu9VslOAewG3wqTHXFWLsqQy2dxTpuioio3uSkDxAHG9qmA62arKfvQ3swg==
+"@melonproject/token-math@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@melonproject/token-math/-/token-math-0.0.10.tgz#87874fd1d052a0145d5383c85a5f067a9b083fbe"
+  integrity sha512-OqiMmS1NT8bQ4ZUDY9xO8HfWV+D3Xq3fq8fRoNGbcSJmw+XatVnCQcJoY5kDE6FrPCGHnmg9VCGCueiy5pLy4w==
   dependencies:
     bn.js "^4.11.8"
     web3-utils "^1.0.0-beta.36"
@@ -1758,11 +1758,6 @@ babel-plugin-syntax-export-extensions@^6.8.0:
   resolved "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz#70a1484f0f9089a4e84ad44bac353c95b9b12721"
   integrity sha1-cKFITw+QiaToStRLrDU8lbmxJyE=
 
-babel-plugin-syntax-flow@^6.18.0:
-  version "6.18.0"
-  resolved "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
-  integrity sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=
-
 babel-plugin-syntax-function-bind@^6.8.0:
   version "6.13.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.13.0.tgz#48c495f177bdf31a981e732f55adc0bdd2601f46"
@@ -2041,14 +2036,6 @@ babel-plugin-transform-export-extensions@^6.22.0:
     babel-plugin-syntax-export-extensions "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-flow-strip-types@^6.22.0:
-  version "6.22.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
-  integrity sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=
-  dependencies:
-    babel-plugin-syntax-flow "^6.18.0"
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-function-bind@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.22.0.tgz#c6fb8e96ac296a310b8cf8ea401462407ddf6a97"
@@ -2125,13 +2112,6 @@ babel-preset-es2015@^6.24.1:
     babel-plugin-transform-es2015-typeof-symbol "^6.22.0"
     babel-plugin-transform-es2015-unicode-regex "^6.24.1"
     babel-plugin-transform-regenerator "^6.24.1"
-
-babel-preset-flow@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
-  integrity sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=
-  dependencies:
-    babel-plugin-transform-flow-strip-types "^6.22.0"
 
 babel-preset-jest@^23.2.0:
   version "23.2.0"


### PR DESCRIPTION
Sorry guys, but I changed the public API of token-math a bit. But also now it has a documentation: https://github.com/melonproject/token-math#high-level-concepts

So the main points are:
- The exported objects are now lower-case: `import { token } from '@melonproject/token-math';` instead of `import { token } from '@melonproject/token-math';`
- The exported interfaces are now named `FooInterface` instead of `IFoo`. This `I` was hurting my eyes.
- The `QuantityInterface` does not inherit from `TokenInterface` anymore. This led to confusion. Now, the associated token is named explicitely: `quantity.token: Token`. This aligns with the good ol' principle: "Composition over inheritance".

If you do not agree with the API design, please feel free to open issues so we can have a conversation: https://github.com/melonproject/token-math/issues. It is still in alpha stage.